### PR TITLE
fix: Startup crash in v1.0.4

### DIFF
--- a/app/proguard-rules.pro
+++ b/app/proguard-rules.pro
@@ -19,3 +19,9 @@
 # If you keep the line number information, uncomment this to
 # hide the original source file name.
 #-renamesourcefileattribute SourceFile
+
+# Keep WorkManager database implementations
+-keep class androidx.work.impl.WorkDatabase_Impl { *; }
+
+# Keep Room database tracking services
+-keep class androidx.room.MultiInstanceInvalidationService { *; }


### PR DESCRIPTION
`java.lang.RuntimeException: Unable to get provider androidx.startup.InitializationProvider: zy: java.lang.RuntimeException: Failed to create an instance of androidx.work.impl.WorkDatabase
	at android.app.ActivityThread.installProvider(ActivityThread.java:8173)
	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7709)
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7573)
	at android.app.ActivityThread.access$2600(ActivityThread.java:260)
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2435)
	at android.os.Handler.dispatchMessage(Handler.java:110)
	at android.os.Looper.loop(Looper.java:219)
	at android.app.ActivityThread.main(ActivityThread.java:8668)
	at java.lang.reflect.Method.invoke(Native Method)
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513)
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)
Caused by: zy: java.lang.RuntimeException: Failed to create an instance of androidx.work.impl.WorkDatabase
	at bk5.f(SourceFile:100)
	at bk5.e(SourceFile:86)
	at androidx.startup.InitializationProvider.onCreate(SourceFile:53)
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2097)
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2070)
	at android.app.ActivityThread.installProvider(ActivityThread.java:8168)
	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7709) 
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7573) 
	at android.app.ActivityThread.access$2600(ActivityThread.java:260) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2435) 
	at android.os.Handler.dispatchMessage(Handler.java:110) 
	at android.os.Looper.loop(Looper.java:219) 
	at android.app.ActivityThread.main(ActivityThread.java:8668) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109) 
Caused by: java.lang.RuntimeException: Failed to create an instance of androidx.work.impl.WorkDatabase
	at rs3.<init>(SourceFile:595)
	at rs3.c(SourceFile:44)
	at androidx.work.WorkManagerInitializer.b(SourceFile:27)
	at bk5.f(SourceFile:86)
	at bk5.e(SourceFile:86) 
	at androidx.startup.InitializationProvider.onCreate(SourceFile:53) 
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2097) 
	at android.content.ContentProvider.attachInfo(ContentProvider.java:2070) 
	at android.app.ActivityThread.installProvider(ActivityThread.java:8168) 
	at android.app.ActivityThread.installContentProviders(ActivityThread.java:7709) 
	at android.app.ActivityThread.handleBindApplication(ActivityThread.java:7573) 
	at android.app.ActivityThread.access$2600(ActivityThread.java:260) 
	at android.app.ActivityThread$H.handleMessage(ActivityThread.java:2435) 
	at android.os.Handler.dispatchMessage(Handler.java:110) 
	at android.os.Looper.loop(Looper.java:219) 
	at android.app.ActivityThread.main(ActivityThread.java:8668) 
	at java.lang.reflect.Method.invoke(Native Method) 
	at com.android.internal.os.RuntimeInit$MethodAndArgsCaller.run(RuntimeInit.java:513) 
	at com.android.internal.os.ZygoteInit.main(ZygoteInit.java:1109)`


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Chores**
  * Updated build configuration to preserve critical database components during app compilation, ensuring stable database operations at runtime.

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/shubertm/Amuzic/pull/95?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->